### PR TITLE
Update url for Humanloop API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is an example pet name generator app used in the OpenAI API [quickstart tut
    $ cp .env.example .env
    ```
 
-6. Add your OpenAI [API key](https://beta.openai.com/account/api-keys) to the newly created `.env` as `OPEN_API_KEY=...` and add your Humanloop [API key](https://app.humanloop.com/llama/settings) as `HUMANLOOP_API_KEY=...`
+6. Add your OpenAI [API key](https://beta.openai.com/account/api-keys) to the newly created `.env` as `OPEN_API_KEY=...` and add your Humanloop [API key](https://app.humanloop.com/account/api-keys) as `HUMANLOOP_API_KEY=...`
 
 7. Run the app
 


### PR DESCRIPTION
Hi all, I noticed the URL for the API key is broken. This PR updates it to the current one: https://app.humanloop.com/account/api-keys

You might want to look through your docs for other places where the link might need to be updated. For example, this page: https://docs.humanloop.com/docs/create-your-first-gpt-3-app#1-open-the-humanloop-playground

Thanks for all you do! I'm excited to start exploring Humanloop.